### PR TITLE
buildXPathQuery fixed "finishing" 

### DIFF
--- a/css_to_inline_styles.php
+++ b/css_to_inline_styles.php
@@ -152,7 +152,8 @@ class CSSToInlineStyles
 							);
 
 		// return
-		return (string) '//' . preg_replace($cssSelector, $xPathQuery, $selector);
+		$str = (string) '//' . preg_replace($cssSelector, $xPathQuery, $selector);
+		return str_replace( '] *', ']//*', $str);
 	}
 
 


### PR DESCRIPTION
# id #id, #id .cls, etc were not properly delimited by '//' in xpath
