### PR TITLE
Updated the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
 		}
 	],
 	"require": {
-		"php": ">=5.2.0",
-		"ext-curl": "*"
+		"php": ">=5.2.0"
 	},
+	"target-dir": "TijsVerkoyen/CssToInlineStyles",
 	"autoload": {
-		"classmap": [""]
+		"psr-0": {"TijsVerkoyen\\CssToInlineStyles": ""}
 	}
 }


### PR DESCRIPTION
There is no dependency to ext-curl and this optimizes the classmap
to check only the file containing the code.
