### PR TITLE
Fixed the XPath query for selectors with a class or id descendant

### DIFF
--- a/CssToInlineStyles.php
+++ b/CssToInlineStyles.php
@@ -134,7 +134,9 @@ class CssToInlineStyles
         );
 
         // return
-        return (string) '//' . preg_replace($cssSelector, $xPathQuery, $selector);
+        $xPath = (string) '//' . preg_replace($cssSelector, $xPathQuery, $selector);
+
+        return str_replace('] *', ']//*', $xPath);
     }
 
     /**


### PR DESCRIPTION
The XPath query generated for selectors like ".foo .bar" was broken.
This replaces #10 to apply it on the renamed file.
