### PR TITLE
Added the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
 	"target-dir": "TijsVerkoyen/CssToInlineStyles",
 	"autoload": {
 		"psr-0": {"TijsVerkoyen\\CssToInlineStyles": ""}
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "1.2.x-dev"
+		}
 	}
 }


### PR DESCRIPTION
This allows other packages to define a range requirement (`1.2.*` for instance) and still being able to have the dev version matching the requirement.

Of course, this will need to be bumped once you release `1.3.0`
