### PR TITLE
xhtml leaving character behind at start of file

### DIFF
--- a/CssToInlineStyles.php
+++ b/CssToInlineStyles.php
@@ -448,7 +448,7 @@ class CssToInlineStyles
                 $endPosition = strpos($html, '?>', $startPosition);
 
                 // remove the XML-header
-                $html = ltrim(substr($html, $endPosition + 1));
+                $html = ltrim(substr($html, $endPosition + 2));
             }
         }
 


### PR DESCRIPTION
kept leaving a '>' of the xml declaration. This fixed it. Why not do this with grep?
