### PR TITLE
handle tags with no spaces after class or id attributes when cleaning up html

### DIFF
--- a/CssToInlineStyles.php
+++ b/CssToInlineStyles.php
@@ -189,10 +189,10 @@ class CssToInlineStyles
     private function cleanupHTML($html)
     {
         // remove classes
-        $html = preg_replace('/(\s)+class="(.*)"(\s)+/U', ' ', $html);
+        $html = preg_replace('/(\s)+class="(.*)"(\s)*/U', ' ', $html);
 
         // remove IDs
-        $html = preg_replace('/(\s)+id="(.*)"(\s)+/U', ' ', $html);
+        $html = preg_replace('/(\s)+id="(.*)"(\s)*/U', ' ', $html);
 
         // return
         return $html;


### PR DESCRIPTION
The cleanupHTML function wasn't correctly handling elements with no space after the class or id. For example,

``` php
echo preg_replace('/(\s)+class="(.*)"(\s)+/U', ' ', '<img src="foo.jpg" class="something"><span class="bar" >bar</span>');
// prints '<img src="foo.jpg" >bar</span>'
```

This change makes whitespace after the last quote optional.
