### PR TITLE
Fixed sortOnSpecifity sort order.

### DIFF
--- a/CssToInlineStyles.php
+++ b/CssToInlineStyles.php
@@ -707,16 +707,12 @@ class CssToInlineStyles
      */
     private static function sortOnSpecifity($e1, $e2)
     {
-        // validate
-        if(!isset($e1['specifity']) || !isset($e2['specifity'])) return 0;
+        // don't need to validate ...
+        //if (!isset($e1['specifity']) || !isset($e2['specifity'])) return 0;
 
-        // lower
-        if($e1['specifity'] < $e2['specifity']) return -1;
-
-        // higher
-        if($e1['specifity'] > $e2['specifity']) return 1;
-
-        // fallback
-        return 0;
+        if ($e1['specificity'] == $e2['specificity']) {
+            return 0;
+        }
+        return $e1['specificity'] > $e2['specificity'] ? -1 : 1;
     }
 }


### PR DESCRIPTION
sortOnSpecifity is not actually sorting correctly. Your current sort routine produces something like this:

```
102: #pre-header > tr > td
100: #pre-header
101: #pre-header a
102: #header > tr > td
100: #content
100: #header
100: #main
13: table.box-contents tr > td
23: table.box-contents tr > td:nth-child(odd)
23: table.box-contents tr > td:nth-child(even)
100: #backgroundTable
112: #content div a:link
112: #content div a:visited
1: body
112: #footer td a .yshortcuts
10: .ReadMsgBody
10: .ExternalClass
```

The updated routine produces the correct result:

```
112: #content div a .yshortcuts
112: #content div a:link
112: #footer td a:link
112: #content div a:visited
112: #footer td a .yshortcuts
112: #footer td a:visited
102: #pre-header > tr > td
102: #header > tr > td
101: #footer td
101: #pre-header a
101: #content img
100: #header
100: #main
100: #pre-header
100: #content
100: #footer
100: #backgroundTable
```

Also note, there's no reason to have the validation check in your sort routine. It just slows it down. So I comment that out.
