### PR TITLE
Problem with ISO-8859-1 in html convert

### DIFF
--- a/CssToInlineStyles.php
+++ b/CssToInlineStyles.php
@@ -237,9 +237,12 @@ class CssToInlineStyles
         // set error level
         libxml_use_internal_errors(true);
         
-        //Check if html has ISO encoding and convert to UTF-8
+        //Check if html has ISO encoding and convert to UTF-8 only if $this->cssRules is empty
         $htmlEncode = mb_detect_encoding($this->html, array('ISO-8859-1','UTF-8'));
-        if($htmlEncode == 'ISO-8859-1'){                    
+        if($htmlEncode == 'ISO-8859-1'){
+            if(empty($this->cssRules)){
+                return $this->html;
+            }
             $this->html = utf8_encode($this->html);
         }
         


### PR DESCRIPTION
If a html passed to `__construct()` has a ISO-8859-1 encoding, the `CssToInlineStyles::convert()` method return a crazy html string. That's fixed with check the html encode and force it to utf-8.
