### PR TITLE
fixed sortOnSpecifity: operator reversed and missing parentheses in comparison condition

### DIFF
--- a/CssToInlineStyles.php
+++ b/CssToInlineStyles.php
@@ -710,6 +710,6 @@ class CssToInlineStyles
         if ($e1['specifity'] == $e2['specifity']) {
             return 0;
         }
-        return $e1['specifity'] > $e2['specifity'] ? -1 : 1;
+        return ($e1['specifity'] < $e2['specifity']) ? -1 : 1;
     }
 }


### PR DESCRIPTION
fixed 

``` php
    private static function sortOnSpecifity($e1, $e2)
    {
        if ($e1['specifity'] == $e2['specifity']) {
            return 0;
        }
        return $e1['specifity'] > $e2['specifity'] ? -1 : 1; //was
        return ($e1['specifity'] < $e2['specifity']) ? -1 : 1; //now
    }
```

with template from: [php.net/usort](http://www.php.net/manual/en/function.usort.php)

``` php
function cmp($a, $b)
{
    if ($a == $b) {
        return 0;
    }
    return ($a < $b) ? -1 : 1;
}
```
