### PR TITLE
Fixed the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.2.x-dev"
+			"dev-master": "1.3.x-dev"
 		}
 	}
 }


### PR DESCRIPTION
1.3.0 has been released, so master cannot be 1.2.x-dev
