### PR TITLE
Replaced the regex-based transformation of CSS to XPath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/composer.lock

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 
 PHP CssToInlineStyles is a class to convert HTML into HTML with inline styles.
 
+## Installation
+
+The recommended installation way is through [Composer](https://getcomposer.org).
+
+```bash
+$ composer require tijsverkoyen/css-to-inline-styles '~1.3'
+```
+
 ## Documentation
 
 The class is well documented inline. If you use a decent IDE you'll see that

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.0"
+		"php": ">=5.3.0",
+		"symfony/css-selector": "~2.0"
 	},
 	"target-dir": "TijsVerkoyen/CssToInlineStyles",
 	"autoload": {

--- a/tests/index.php
+++ b/tests/index.php
@@ -1,7 +1,7 @@
 <?php
 
 //require
-require_once '../../../autoload.php';
+require_once '../vendor/autoload.php';
 require_once 'config.php';
 
 use \TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;


### PR DESCRIPTION
The library now uses the Symfony CssSelector component, which supports more cases than the custom logic used previously.
Closes #34

I updated the doc to mention composer as the recommended installation way, as this takes care of including the CssSelector component automatically.
Btw, don't forget to update the composer.json again when bumping the version after this change :)
