### PR TITLE
Increase base for specifity

### DIFF
--- a/CssToInlineStyles.php
+++ b/CssToInlineStyles.php
@@ -550,7 +550,7 @@ class CssToInlineStyles
                 // calculate specifity
                 $ruleSet['specifity'] = $this->calculateCSSSpecifity(
                     $selector
-                ) + $i;
+                ) + ($i/1000);
 
                 // add into global rules
                 $this->cssRules[] = $ruleSet;


### PR DESCRIPTION
Following http://www.w3.org/TR/selectors/#specificity, the specifity is concatenating a,b and c. It notes that the base should be large enough. So it should be something like 2,9,3= 293, but 2,11,3 (=313) should be lower then 3,0,0 (300). This make 2,11,3 = 21103 and 3,0,0 = 30000. So it is still not always perfect, but better ;)
