### PR TITLE
Alternative change for specificity

### DIFF
--- a/CssToInlineStyles.php
+++ b/CssToInlineStyles.php
@@ -481,8 +481,11 @@ class CssToInlineStyles
                 // calculate specifity
                 $ruleSet['specifity'] = $this->calculateCSSSpecifity(
                     $selector
-                ) + $i;
+                );
 
+                // remember the order of appearance
+                $ruleSet['order'] = $i;
+                
                 // add into global rules
                 $this->cssRules[] = $ruleSet;
             }
@@ -638,9 +641,12 @@ class CssToInlineStyles
      */
     private static function sortOnSpecifity($e1, $e2)
     {
-        if ($e1['specifity'] == $e2['specifity']) {
-            return 0;
+        if ($e1['specifity'] !== $e2['specifity']) {
+            return ($e1['specifity'] < $e2['specifity']) ? -1 : 1;
+        } elseif ($e1['order'] !== $e2['order']) {
+            return ($e1['order'] < $e2['order']) ? -1 : 1;
         }
-        return ($e1['specifity'] < $e2['specifity']) ? -1 : 1;
+
+        return 0;
     }
 }


### PR DESCRIPTION
This is an alternative to #59

The patch in #59 is better, but this illustrates the problem better. The order shouldn't have any effect on the specificity, it should only count when the specificity is the same..
