### PR TITLE
Tweak important detect

### DIFF
--- a/CssToInlineStyles.php
+++ b/CssToInlineStyles.php
@@ -256,7 +256,7 @@ class CssToInlineStyles
                         if (
                             !isset($properties[$key])
                             || stristr($properties[$key], '!important') === false
-                            || (is_string($value) && stristr($value, '!important') !== false)
+                            || (stristr(implode('', $value), '!important') !== false)
                         ) {
                             $properties[$key] = $value;
                         }


### PR DESCRIPTION
The $value is always an array, not a string. Implode them before checking, instead of skipping.
The earlier version did work a bit, bit had problems with multiple !important statements.
See https://github.com/tijsverkoyen/CssToInlineStyles/pull/59#issuecomment-50123365
