### PR TITLE
Exclude vendor files from coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,4 +17,13 @@
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
+    
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">src</directory>
+            <exclude>
+                <directory suffix=".php">vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Not 100% sure, but this should stop the vendor files being included in the coverage.
