### PR TITLE
Set excludeMediaQueries to true as default

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -68,7 +68,7 @@ class CssToInlineStyles
      *
      * @var bool
      */
-    private $excludeMediaQueries = false;
+    private $excludeMediaQueries = true;
 
     /**
      * Creates an instance, you could set the HTML and CSS here, or load it


### PR DESCRIPTION
I think including the mediaqueries in the inline-styles is a bit counter-intuitive, as they don't really belong inline.

This didn't really matter before #52 as they weren't processed properly (I think?) but after that change, it kind of messes up the layout. With Zurb Ink, in 1.2.x the flag doesn't have any effect. In 1.5.x, it only works correctly when media queries are excluded. So as this may look like a breaking change, imho the change in #52 broke this behaviour and this change is more 'reasonable'.

(Split of #54 for just this issue)
