### PR TITLE
Added a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto
+
+/example export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/Gemfile export-ignore
+/phpunit.xml export-ignore
+/CHANGELOG.md export-ignore
+/README.md export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/vendor/
+/vendor
 composer.lock
 Gemfile.lock


### PR DESCRIPTION
This is so when people are installing this through composer, they only get the required source files. This saves disk space for the user user, and saves github's bandwidth.
