### PR TITLE
Deprecate encoding

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -567,6 +567,8 @@ class CssToInlineStyles
      *
      * @return void
      * @param  string $encoding The encoding to use.
+     * 
+     * @deprecated Doesn't have any effect
      */
     public function setEncoding($encoding)
     {


### PR DESCRIPTION
The encoding isn't used when loading HTML, so shouldn't be used. But we shouldn't remove this as it will break apps, so deprecate it until the next major release.
