### PR TITLE
Clarifying License Type

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -10,7 +10,7 @@ use Symfony\Component\CssSelector\Exception\ExceptionInterface;
  * @author         Tijs Verkoyen <php-css-to-inline-styles@verkoyen.eu>
  * @version        1.5.2
  * @copyright      Copyright (c), Tijs Verkoyen. All rights reserved.
- * @license        BSD License
+ * @license        Revised BSD License
  */
 class CssToInlineStyles
 {


### PR DESCRIPTION
The original BSD license isn't compatible with the GPL license that I use with WordPress plugins but the revised BSD license you have in `LICENSE.md` [*is* compatible](http://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_.28.22Revised_BSD_License.22.2C_.22New_BSD_License.22.2C_or_.22Modified_BSD_License.22.29). I wanted to clarify for future users who want to include this in their projects and need to know exactly which license you're using.