### PR TITLE
reset css rules when new css is set

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -71,6 +71,12 @@ class CssToInlineStyles
     private $excludeMediaQueries = true;
 
     /**
+     * Whether css was already processed and there's no need to do it again
+     * @var bool
+     */
+    private $isCssProcessed = false;
+
+    /**
      * Creates an instance, you could set the HTML and CSS here, or load it
      * later.
      *
@@ -140,7 +146,9 @@ class CssToInlineStyles
         }
 
         // process css
-        $this->processCSS();
+        if (!$this->isCssProcessed) {
+            $this->processCSS();
+        }
 
         // create new DOMDocument
         $document = new \DOMDocument('1.0', $this->getEncoding());
@@ -417,6 +425,8 @@ class CssToInlineStyles
      */
     private function processCSS()
     {
+        //reset current set of rules
+        $this->cssRules = array();
         // init vars
         $css = (string) $this->css;
 
@@ -495,6 +505,7 @@ class CssToInlineStyles
         if (!empty($this->cssRules)) {
             usort($this->cssRules, array(__CLASS__, 'sortOnSpecificity'));
         }
+        $this->isCssProcessed = true;
     }
 
     /**
@@ -560,6 +571,7 @@ class CssToInlineStyles
     public function setCSS($css)
     {
         $this->css = (string) $css;
+        $this->isCssProcessed = false;
     }
 
     /**

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -22,11 +22,11 @@ class CssToInlineStyles
     private $css;
 
     /**
-     * The processed CSS rules
+     * The processed CSS rules cache
      *
      * @var    array
      */
-    private $cssRules;
+    private $cssRulesCache = array();
 
     /**
      * Should the generated HTML be cleaned
@@ -69,12 +69,6 @@ class CssToInlineStyles
      * @var bool
      */
     private $excludeMediaQueries = true;
-
-    /**
-     * Whether css was already processed and there's no need to do it again
-     * @var bool
-     */
-    private $isCssProcessed = false;
 
     /**
      * Creates an instance, you could set the HTML and CSS here, or load it
@@ -128,6 +122,7 @@ class CssToInlineStyles
             throw new Exception('No HTML provided.');
         }
 
+        $cssRules = [];
         // should we use inline style-block
         if ($this->useInlineStylesBlock) {
             // init var
@@ -136,18 +131,26 @@ class CssToInlineStyles
             // match the style blocks
             preg_match_all('|<style(.*)>(.*)</style>|isU', $this->html, $matches);
 
+            $inlineCss = '';
             // any style-blocks found?
             if (!empty($matches[2])) {
                 // add
                 foreach ($matches[2] as $match) {
-                    $this->css .= trim($match) . "\n";
+                    $inlineCss .= trim($match) . "\n";
                 }
             }
+
+            $cssRules = $this->processCSS($inlineCss);
         }
 
         // process css
-        if (!$this->isCssProcessed) {
-            $this->processCSS();
+        if ($this->css) {
+            $cssRules = array_merge($cssRules, $this->processCSS($this->css));
+        }
+
+        // sort based on specificity
+        if (!empty($cssRules)) {
+            usort($cssRules, array(__CLASS__, 'sortOnSpecificity'));
         }
 
         // create new DOMDocument
@@ -163,9 +166,9 @@ class CssToInlineStyles
         $xPath = new \DOMXPath($document);
 
         // any rules?
-        if (!empty($this->cssRules)) {
+        if (!empty($cssRules)) {
             // loop rules
-            foreach ($this->cssRules as $rule) {
+            foreach ($cssRules as $rule) {
                 try {
                     $query = CssSelector::toXPath($rule['selector']);
                 } catch (ExceptionInterface $e) {
@@ -421,91 +424,94 @@ class CssToInlineStyles
     /**
      * Process the loaded CSS
      *
-     * @return void
+     * @param string $css
+     * @return array parsed css rules
      */
-    private function processCSS()
+    private function processCSS($css)
     {
-        //reset current set of rules
-        $this->cssRules = array();
-        // init vars
-        $css = (string) $this->css;
+        $hash = md5($css);
+        if (!isset($this->cssRulesCache[$hash])) {
+            //reset current set of rules
+            $cssRules = array();
+            // init vars
+            $css = (string) $css;
 
-        // remove newlines
-        $css = str_replace(array("\r", "\n"), '', $css);
+            // remove newlines
+            $css = str_replace(array("\r", "\n"), '', $css);
 
-        // replace double quotes by single quotes
-        $css = str_replace('"', '\'', $css);
+            // replace double quotes by single quotes
+            $css = str_replace('"', '\'', $css);
 
-        // remove comments
-        $css = preg_replace('|/\*.*?\*/|', '', $css);
+            // remove comments
+            $css = preg_replace('|/\*.*?\*/|', '', $css);
 
-        // remove spaces
-        $css = preg_replace('/\s\s+/', ' ', $css);
+            // remove spaces
+            $css = preg_replace('/\s\s+/', ' ', $css);
 
-        if ($this->excludeMediaQueries) {
-            $css = preg_replace('/@media [^{]*{([^{}]|{[^{}]*})*}/', '', $css);
-        }
-
-        // rules are splitted by }
-        $rules = (array) explode('}', $css);
-
-        // init var
-        $i = 1;
-
-        // loop rules
-        foreach ($rules as $rule) {
-            // split into chunks
-            $chunks = explode('{', $rule);
-
-            // invalid rule?
-            if (!isset($chunks[1])) {
-                continue;
+            if ($this->excludeMediaQueries) {
+                $css = preg_replace('/@media [^{]*{([^{}]|{[^{}]*})*}/', '', $css);
             }
 
-            // set the selectors
-            $selectors = trim($chunks[0]);
+            // rules are splitted by }
+            $rules = (array) explode('}', $css);
 
-            // get cssProperties
-            $cssProperties = trim($chunks[1]);
+            // init var
+            $i = 1;
 
-            // split multiple selectors
-            $selectors = (array) explode(',', $selectors);
+            // loop rules
+            foreach ($rules as $rule) {
+                // split into chunks
+                $chunks = explode('{', $rule);
 
-            // loop selectors
-            foreach ($selectors as $selector) {
-                // cleanup
-                $selector = trim($selector);
+                // invalid rule?
+                if (!isset($chunks[1])) {
+                    continue;
+                }
 
-                // build an array for each selector
-                $ruleSet = array();
+                // set the selectors
+                $selectors = trim($chunks[0]);
 
-                // store selector
-                $ruleSet['selector'] = $selector;
+                // get cssProperties
+                $cssProperties = trim($chunks[1]);
 
-                // process the properties
-                $ruleSet['properties'] = $this->processCSSProperties(
-                    $cssProperties
-                );
+                // split multiple selectors
+                $selectors = (array) explode(',', $selectors);
 
-                // calculate specificity
-                $ruleSet['specificity'] = Specificity::fromSelector($selector);
+                // loop selectors
+                foreach ($selectors as $selector) {
+                    // cleanup
+                    $selector = trim($selector);
 
-                // remember the order in which the rules appear
-                $ruleSet['order'] = $i;
+                    // build an array for each selector
+                    $ruleSet = array();
 
-                // add into global rules
-                $this->cssRules[] = $ruleSet;
+                    // store selector
+                    $ruleSet['selector'] = $selector;
+
+                    // process the properties
+                    $ruleSet['properties'] = $this->processCSSProperties(
+                        $cssProperties
+                    );
+
+                    // calculate specificity
+                    $ruleSet['specificity'] = Specificity::fromSelector($selector);
+
+                    // remember the order in which the rules appear
+                    $ruleSet['order'] = $i;
+
+                    // add into global rules
+                    $cssRules[] = $ruleSet;
+                }
+
+                // increment
+                $i++;
             }
 
-            // increment
-            $i++;
+            $this->cssRulesCache[$hash] = $cssRules;
         }
 
-        // sort based on specificity
-        if (!empty($this->cssRules)) {
-            usort($this->cssRules, array(__CLASS__, 'sortOnSpecificity'));
-        }
-        $this->isCssProcessed = true;
+
+        return $this->cssRulesCache[$hash];
     }
 
     /**
@@ -571,7 +577,6 @@ class CssToInlineStyles
     public function setCSS($css)
     {
         $this->css = (string) $css;
-        $this->isCssProcessed = false;
     }
 
     /**

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -122,7 +122,7 @@ class CssToInlineStyles
             throw new Exception('No HTML provided.');
         }
 
-        $cssRules = [];
+        $cssRules = array();
         // should we use inline style-block
         if ($this->useInlineStylesBlock) {
             // init var

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -169,6 +169,20 @@ EOF;
         $this->runHTMLToCSS($html, $css, $expected);
     }
 
+    public function testCssRulesResetDuringSecondLoad()
+    {
+        $html = "<p></p>";
+        $css = 'p { margin: 10px; }';
+        $expected = '<p style="margin: 10px;"></p>';
+
+        $this->runHTMLToCSS($html, $css, $expected);
+
+        $html = "<p></p>";
+        $css = 'p { padding: 10px; }';
+        $expected = '<p style="padding: 10px;"></p>';
+        $this->runHTMLToCSS($html, $css, $expected);
+    }
+
     private function runHTMLToCSS($html, $css, $expected, $asXHTML = false)
     {
         $cssToInlineStyles = $this->cssToInlineStyles;

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -6,6 +6,9 @@ use \TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 class CssToInlineStylesTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var CssToInlineStyles
+     */
     protected $cssToInlineStyles;
 
     public function setUp()
@@ -181,6 +184,30 @@ EOF;
         $css = 'p { padding: 10px; }';
         $expected = '<p style="padding: 10px;"></p>';
         $this->runHTMLToCSS($html, $css, $expected);
+    }
+
+    public function testCssRulesInlineResetDuringSecondLoad()
+    {
+        $html = "<p></p>";
+        $css = 'p { margin: 10px; }';
+        $expected = '<p style="margin: 10px;"></p>';
+
+        $this->runHTMLToCSS($html, $css, $expected);
+
+        $html = <<<HTML
+<style>
+    p {
+        padding: 10px;
+    }
+</style>
+<p></p>
+HTML;
+
+        $css = 'p { margin: 10px; }';
+
+        $this->runHTMLToCSS($html, $css, '<p style="margin: 10px;"></p>');
+        $this->cssToInlineStyles->setUseInlineStylesBlock(true);
+        $this->runHTMLToCSS($html, $css, '<p style="margin: 10px; padding: 10px;"></p>');
     }
 
     private function runHTMLToCSS($html, $css, $expected, $asXHTML = false)

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -207,7 +207,7 @@ HTML;
 
         $this->runHTMLToCSS($html, $css, '<p style="margin: 10px;"></p>');
         $this->cssToInlineStyles->setUseInlineStylesBlock(true);
-        $this->runHTMLToCSS($html, $css, '<p style="margin: 10px; padding: 10px;"></p>');
+        $this->runHTMLToCSS('<p></p>', $css, '<p style="margin: 10px;"></p>');
     }
 
     private function runHTMLToCSS($html, $css, $expected, $asXHTML = false)


### PR DESCRIPTION
Hello,

This PR fixes issue when reusing same instance of CssToInlineStyles class for inlining, e.g. in bulk emails option. Also it speeds up inlining css a bit for bulk emails by parsing css only once.

Regards,
Alex