### PR TITLE
Use DOM instead of regexp in cleanupHTML()

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -89,21 +89,18 @@ class CssToInlineStyles
     }
 
     /**
-     * Cleanup the generated HTML
+     * Remove id and class attributes.
      *
      * @return string
-     * @param  string $html The HTML to cleanup.
+     * @param  \DOMXPath $xPath The DOMXPath for the entire document.
      */
-    private function cleanupHTML($html)
+    private function cleanupHTML(\DOMXPath $xPath)
     {
-        // remove classes
-        $html = preg_replace('/(\s)+class="(.*)"(\s)*/U', ' ', $html);
+        $nodes = $xPath->query('//@class | //@id');
 
-        // remove IDs
-        $html = preg_replace('/(\s)+id="(.*)"(\s)*/U', ' ', $html);
-
-        // return
-        return $html;
+        foreach ($nodes as $node) {
+            $node->ownerElement->removeAttributeNode($node);
+        }
     }
 
     /**
@@ -368,6 +365,11 @@ class CssToInlineStyles
             $this->stripOriginalStyleTags($xPath);
         }
 
+        // cleanup the HTML if we need to
+        if ($this->cleanup) {
+            $this->cleanupHTML($xPath);
+        }
+
         // should we output XHTML?
         if ($outputXHTML) {
             // set formating
@@ -382,11 +384,6 @@ class CssToInlineStyles
         else {
             // get the HTML
             $html = $document->saveHTML();
-        }
-
-        // cleanup the HTML if we need to
-        if ($this->cleanup) {
-            $html = $this->cleanupHTML($html);
         }
 
         // return

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -139,9 +139,9 @@ EOF;
 
     public function testCleanup()
     {
-        $html = '<div id="id" class="className"></div>';
+        $html = '<div id="id" class="className"> id="foo" class="bar" </div>';
         $css = ' #id { display: inline; } .className { margin-right: 10px; }';
-        $expected = '<div style="margin-right: 10px; display: inline;"></div>';
+        $expected = '<div style="margin-right: 10px; display: inline;"> id="foo" class="bar" </div>';
         $this->cssToInlineStyles->setCleanup();
         $this->runHTMLToCSS($html, $css, $expected);
     }


### PR DESCRIPTION
Manipulating HTML using regular expressions is error prone.

The code in cleanupHTML() matches more that it should and converts e.g. `<p> id="123" </p>` to `<p> </p>` even though it should be left unchanged.

This PR changes cleanupHTML() to use DOM methods instead.