### PR TITLE
Fixed stripping of XML header when outputting XHTML

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -379,7 +379,7 @@ class CssToInlineStyles
             $html = $document->saveXML(null, LIBXML_NOEMPTYTAG);
 
             // remove the XML-header
-            $html = ltrim(preg_replace('/<?xml (.*)?>/', '', $html));
+            $html = ltrim(preg_replace('/<\?xml (.*)\?>/', '', $html));
         } // just regular HTML 4.01 as it should be used in newsletters
         else {
             // get the HTML

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -175,11 +175,20 @@ EOF;
     public function testXMLHeaderIsRemoved()
     {
         $html = '<html><body><p>Foo</p></body>';
+        $expected = <<<EOF
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html>
+  <body>
+    <p>Foo</p>
+  </body>
+</html>
 
+EOF;
         $this->cssToInlineStyles->setHTML($html);
         $this->cssToInlineStyles->setCSS('');
+        $actual = $this->cssToInlineStyles->convert(true);
 
-        $this->assertNotContains('<?xml', $this->cssToInlineStyles->convert(true));
+        $this->assertEquals($expected, $actual);
     }
 
     private function runHTMLToCSS($html, $css, $expected, $asXHTML = false)


### PR DESCRIPTION
I've cherry-picked @barryvdh's test case and @rvock's fix and put them in a single pull request for your convenience. This should fix issue #96, making sure the XML header is properly removed from the output.