### PR TITLE
[2.0] Use ExceptionInterface instead of SyntaxErrorException

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -4,7 +4,7 @@ namespace TijsVerkoyen\CssToInlineStyles;
 
 use Symfony\Component\CssSelector\CssSelector;
 use Symfony\Component\CssSelector\CssSelectorConverter;
-use Symfony\Component\CssSelector\Exception\ParseException;
+use Symfony\Component\CssSelector\Exception\ExceptionInterface;
 use TijsVerkoyen\CssToInlineStyles\Css\Processor;
 use TijsVerkoyen\CssToInlineStyles\Css\Property\Processor as PropertyProcessor;
 use TijsVerkoyen\CssToInlineStyles\Css\Rule\Rule;
@@ -146,7 +146,7 @@ class CssToInlineStyles
                 } else {
                     $expression = CssSelector::toXPath($rule->getSelector());
                 }
-            } catch (ParseException $e) {
+            } catch (ExceptionInterface $e) {
                 continue;
             }
 

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -4,7 +4,7 @@ namespace TijsVerkoyen\CssToInlineStyles;
 
 use Symfony\Component\CssSelector\CssSelector;
 use Symfony\Component\CssSelector\CssSelectorConverter;
-use Symfony\Component\CssSelector\Exception\SyntaxErrorException;
+use Symfony\Component\CssSelector\Exception\ParseException;
 use TijsVerkoyen\CssToInlineStyles\Css\Processor;
 use TijsVerkoyen\CssToInlineStyles\Css\Property\Processor as PropertyProcessor;
 use TijsVerkoyen\CssToInlineStyles\Css\Rule\Rule;
@@ -146,7 +146,7 @@ class CssToInlineStyles
                 } else {
                     $expression = CssSelector::toXPath($rule->getSelector());
                 }
-            } catch (SyntaxErrorException $e) {
+            } catch (ParseException $e) {
                 continue;
             }
 


### PR DESCRIPTION
SyntaxErrorException extends ParseException. Now also other exceptions are caught.

In my case:
> Fatal error:  Uncaught exception 'Symfony\Component\CssSelector\Exception\ExpressionErrorException' with message 'Pseudo-class "active" not supported.' in /var/www/html/inlinetest/vendor/symfony/css-selector/XPath/Translator.php:259