### PR TITLE
README example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,14 @@ $ composer require tijsverkoyen/css-to-inline-styles
 
     use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
-    // create instance
-    $cssToInlineStyles = new CssToInlineStyles();
-
     $html = file_get_contents(__DIR__ . '/examples/sumo/index.htm');
     $css = file_get_contents(__DIR__ . '/examples/sumo/style.css');
 
+    // create instance
+    $cssToInlineStyles = new CssToInlineStyles($html, $css);
+
     // output
-    echo $cssToInlineStyles->convert(
-        $html,
-        $css
-    );
+    echo $cssToInlineStyles->convert();
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ $ composer require tijsverkoyen/css-to-inline-styles
 * [Each site based on Fork CMS](http://www.fork-cms.com)
 * [Print en Bind](http://www.printenbind.nl)
 * [Tiki Wiki CMS Groupware](http://sourceforge.net/p/tikiwiki/code/49505) (starting in Tiki 13)
+* [Implico Email Framework](https://github.com/implico/email-framework)


### PR DESCRIPTION
The constructor takes the HTML and CSS parameters, not the convert method as it was in the example.