### PR TITLE
Add support for UTF-8 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ echo $cssToInlineStyles->convert(
 
 * no support for pseudo selectors
 * no support for [css-escapes](https://mathiasbynens.be/notes/css-escapes)
-* UTF-8 charset is not always detected correctly. Make sure you set the charset to UTF-8 using the following meta-tag in the head: `<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />`. _(Note: using `<meta charset="UTF-8">` does NOT work!)_
 
 ## Sites using this class
 

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -100,11 +100,13 @@ class CssToInlineStyles
      */
     protected function createDomDocumentFromHtml($html)
     {
-        $document = new \DOMDocument('1.0', 'UTF-8');
+        $xml = '<?xml encoding="UTF-8">' . $html;
+        $document = new \DOMDocument();
         $internalErrors = libxml_use_internal_errors(true);
-        $document->loadHTML($html);
+        $document->loadHTML($xml);
         libxml_use_internal_errors($internalErrors);
         $document->formatOutput = true;
+        $document->encoding = 'UTF-8';
 
         return $document;
     }

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -140,6 +140,27 @@ EOF;
         $this->assertCorrectConversion($expected, $html);
     }
 
+    public function testInlineStylesBlockWithUtf8CharactersShouldNotEscapeUtf8Characters()
+    {
+        $html = <<<EOF
+<html>
+<head>
+    <style type="text/css">
+      p {
+        display: none;
+      }
+    </style>
+</head>
+<body>
+    <p>€ ∞ π ⾀ ™ ♠ ♣ ♥ ♦</p>
+</body>
+</html>
+EOF;
+        $expected = '<p style="display: none;">€ ∞ π ⾀ ™ ♠ ♣ ♥ ♦</p>';
+
+        $this->assertCorrectConversion($expected, $html);
+    }
+
     public function testSpecificity()
     {
         $html = <<<EOF


### PR DESCRIPTION
Support UTF-8 characters by adding an XML opening tag containing the encoding. Got the idea from: http://php.net/manual/en/domdocument.loadhtml.php#95251

By encoding it to UTF-8 after html is loaded, the encoding is preserved. Because the encoding is preserved, the UTF-8 characters are not escaped to htmlentities. So `€` stays `€`.

I prefer this, because I think it's not the responsibility of this class to alter the inner content of html nodes.