### PR TITLE
Keep html entities like `&eacute;` and `&euro;` escaped

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -100,12 +100,12 @@ class CssToInlineStyles
      */
     protected function createDomDocumentFromHtml($html)
     {
+        $html = $this->replaceAmperstampToPreserveHtmlEntities($html);
         $html = trim($html);
         if (strstr('<?xml', $html) !== 0) {
             $xmlHeader = '<?xml encoding="utf-8" ?>';
             $html = $xmlHeader . $html;
         }
-
         $document = new \DOMDocument('1.0', 'UTF-8');
         $internalErrors = libxml_use_internal_errors(true);
         $document->loadHTML($html);
@@ -122,6 +122,7 @@ class CssToInlineStyles
     protected function getHtmlFromDocument(\DOMDocument $document)
     {
         $xml = $document->saveXML(null, LIBXML_NOEMPTYTAG);
+        $xml = $this->putReplacedAmperstampBackToPreserveHtmlEntities($xml);
 
         $html = preg_replace(
             '|<\?xml (.*)\?>|',
@@ -247,5 +248,23 @@ class CssToInlineStyles
         );
 
         return $element;
+    }
+
+    /**
+     * @param string $html
+     * @return string
+     */
+    private function replaceAmperstampToPreserveHtmlEntities($html)
+    {
+        return str_replace('&', '!AMP!', $html);
+    }
+
+    /**
+     * @param string $html
+     * @return string
+     */
+    private function putReplacedAmperstampBackToPreserveHtmlEntities($html)
+    {
+        return str_replace('!AMP!', '&', $html);
     }
 }

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -140,6 +140,27 @@ EOF;
         $this->assertCorrectConversion($expected, $html);
     }
 
+    public function testInlineStylesBlockWithHtmlEntities()
+    {
+        $html = <<<EOF
+<html>
+<head>
+    <style type="text/css">
+      p {
+        display: none;
+      }
+    </style>
+</head>
+<body>
+    <p>&amp; &eacute; &euro;</p>
+</body>
+</html>
+EOF;
+        $expected = '<p style="display: none;">&amp; &eacute; &euro;</p>';
+
+        $this->assertCorrectConversion($expected, $html);
+    }
+
     public function testSpecificity()
     {
         $html = <<<EOF


### PR DESCRIPTION
Keep the escaped html entities as is. Instead of changing them to their _ISO 8859-1_ or _UTF-8_ counterparts `é` and `€`.

Html entities should not be touched, since not all everybody understands UTF-8 characters. By not escaping them, the user of this library stays in control.
