### PR TITLE
Detect XML header CssToInlineStyles::createDomDocumentFromHtml()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ echo $cssToInlineStyles->convert(
 
 * no support for pseudo selectors
 * no support for [css-escapes](https://mathiasbynens.be/notes/css-escapes)
-* UTF-8 charset is not always detected correctly. Make sure you set the charset to UTF-8 using the following meta-tag in the head: `<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />`. _(Note: using `<meta charset="UTF-8">` does NOT work!)_
 
 ## Sites using this class
 

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -101,7 +101,7 @@ class CssToInlineStyles
     protected function createDomDocumentFromHtml($html)
     {
         $html = trim($html);
-        if (strstr('<?xml', $html) !== 0) {
+        if (strpos('<?xml', $html) !== 0) {
             $xmlHeader = '<?xml encoding="utf-8" ?>';
             $html = $xmlHeader . $html;
         }


### PR DESCRIPTION
Solve issue with adding xml header twice into DomDocument in #131 

(Luckily DomDocument will handle two xml headers anyway)
