### PR TITLE
html_entity_decode() clears the DOM entities

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -129,6 +129,20 @@ class CssToInlineStyles
             $xml
         );
 
+        /*
+         * Replace entities such as &lt; &gt; with adding extra &
+         * but ignores entities with & following by # such as &#100;
+         * so &lt; will become &amp;lt;
+         * after calling html_entity_decode() &lt; will stay &lt; etc.
+         */
+        $replace = array(
+            '&#60;' => '&lt;',
+            '&#62;' => '&gt;',
+        );
+        $html = str_replace(array_keys($replace), array_values($replace), $html);
+        $html = preg_replace('~(&)([^\#])~', '&amp;$2', $html);
+        $html = html_entity_decode($html, ENT_COMPAT | ENT_HTML401, 'UTF-8');
+
         return ltrim($html);
     }
 

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -200,10 +200,23 @@ EOF;
 
     public function testHtmlEncoding()
     {
-        $text = 'Žluťoučký kůň pije pivo nebo jak to je dál';
-        $expectedText = '&#x17D;lu&#x165;ou&#x10D;k&#xFD; k&#x16F;&#x148; pije pivo nebo jak to je d&#xE1;l';
+        $text = $expectedText = 'Žluťoučký kůň pije pivo nebo jak to je dál @ €';
 
-        $this->assertEquals($expectedText, trim(strip_tags($this->cssToInlineStyles->convert($text, ''))));
+        $this->assertEquals($expectedText, trim(strip_tags($this->cssToInlineStyles->convert($text))));
+    }
+
+    public function testSpecialCharacters()
+    {
+        $text = $expectedText = '1 &lt; 2';
+
+        $this->assertEquals($expectedText, trim(strip_tags($this->cssToInlineStyles->convert($text))));
+    }
+
+    public function testSpecialCharactersExplicit()
+    {
+        $text = $expectedText = '&amp;lt;script&amp;&gt;';
+
+        $this->assertEquals($expectedText, trim(strip_tags($this->cssToInlineStyles->convert($text))));
     }
 
     private function assertCorrectConversion($expected, $html, $css = null)


### PR DESCRIPTION
Although biggest issue with foreign encoding was fixed in #131 the problem is that some e-mail clients such as thunderbird have issues with displaying entities as characters. Therefore is safer to present them UTF-8 characters instead of entities. 