### PR TITLE
Add a test for the removal of comments

### DIFF
--- a/tests/Css/ProcessorTest.php
+++ b/tests/Css/ProcessorTest.php
@@ -44,6 +44,31 @@ EOF;
         $this->assertEquals(1, $rules[0]->getOrder());
     }
 
+    public function testCssWithComments()
+    {
+        $css = <<<CSS
+a {
+    padding: 5px;
+    display: block;
+}
+/* style the titles */
+h1 {
+    color: rebeccapurple;
+}
+/* end of title styles */
+CSS;
+
+        $rules = $this->processor->getRules($css);
+
+        $this->assertCount(2, $rules);
+        $this->assertEquals('a', $rules[0]->getSelector());
+        $this->assertCount(2, $rules[0]->getProperties());
+        $this->assertEquals(1, $rules[0]->getOrder());
+        $this->assertEquals('h1', $rules[1]->getSelector());
+        $this->assertCount(1, $rules[1]->getProperties());
+        $this->assertEquals(2, $rules[1]->getOrder());
+    }
+
     public function testCssWithMediaQueries()
     {
         $css = <<<EOF


### PR DESCRIPTION
When reading the regex, I first wondered whether it supported multiple comments properly. After reading it thoroughly, I figured out it does, because of using a non-greedy quantifier.

But to ensure that things are not broken by mistake in the future, I added a test covering this (so that removing the non-greedy flag by mistake would make the test fail)