### PR TITLE
Add the PHP requirement in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     }
   ],
   "require": {
+    "php": "^5.5 || ^7",
     "symfony/css-selector": "^2.7|~3.0"
   },
   "require-dev": {


### PR DESCRIPTION
This allows knowing the min requirement.

The code tells me that it is at least 5.4 (it uses syntaxes incompatible with 5.3). I went for 5.5 here, because 5.4 was removed from Travis.