### PR TITLE
Fix the detection of style tags

### DIFF
--- a/src/Css/Processor.php
+++ b/src/Css/Processor.php
@@ -32,10 +32,10 @@ class Processor
     {
         $css = '';
         $matches = array();
-        preg_match_all('|<style(.*)>(.*)</style>|isU', $html, $matches);
+        preg_match_all('|<style(?:\s.*)?>(.*)</style>|isU', $html, $matches);
 
-        if (!empty($matches[2])) {
-            foreach ($matches[2] as $match) {
+        if (!empty($matches[1])) {
+            foreach ($matches[1] as $match) {
                 $css .= trim($match) . "\n";
             }
         }

--- a/tests/Css/ProcessorTest.php
+++ b/tests/Css/ProcessorTest.php
@@ -129,6 +129,28 @@ EOF
         );
     }
 
+    public function testStyleTagsWithAttributeInHtml()
+    {
+        $expected = 'p { color: #F00; }' . "\n";
+        $this->assertEquals(
+            $expected,
+            $this->processor->getCssFromStyleTags(
+                <<<HTML
+                    <html>
+    <head>
+        <style type="text/css">
+            p { color: #F00; }
+        </style>
+    </head>
+    <body>
+        <p>foo</p>
+    </body>
+    </html>
+HTML
+            )
+        );
+    }
+
     public function testMultipleStyleTagsInHtml()
     {
         $expected = 'p { color: #F00; }' . "\n" . 'p { color: #0F0; }' . "\n";
@@ -152,5 +174,30 @@ EOF
 EOF
             )
         );
+    }
+
+    public function testWeirdTagsInHtml()
+    {
+        $expected = 'p { color: #F00; }' . "\n";
+        $this->assertEquals(
+            $expected,
+            $this->processor->getCssFromStyleTags(
+                <<<HTML
+                    <html>
+    <head>
+        <!-- weird tag name starting with style -->
+        <stylesheet></stylesheet>
+        <style>
+            p { color: #F00; }
+        </style>
+    </head>
+    <body>
+        <p>foo</p>
+    </body>
+    </html>
+HTML
+            )
+        );
+
     }
 }


### PR DESCRIPTION
The tag name must be followed by a whitespace when we have attributes.
Otherwise, it will be a different tag name.

The test ``testWeirdTagsInHtml`` covered this, because it matched ``</stylesheet>\n        <style>\n            p { color: #F00; }\n`` otherwise.