### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,12 @@ cache:
 matrix:
   include:
     - php: 5.5
+    - php: 5.5
+      env: setup=lowest
     - php: 5.6
     - php: 7.0
+    - php: 7.0
+      env: setup=lowest
     - php: 7.1
     - php: hhvm
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,27 @@ language: php
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 matrix:
   include:
     - php: 5.5
     - php: 5.6
     - php: 7.0
+    - php: 7.1
     - php: hhvm
   allow_failures:
     - php: hhvm
 
-before_script:
-  - composer self-update
-  - composer install --prefer-source  --no-interaction --no-scripts
+env:
+  global:
+    - setup=basic
+
+install:
+  - if [[ $setup = 'basic' ]]; then travis_retry composer install --prefer-dist --no-interaction; fi
+  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable; fi
 
 script:
   - vendor/bin/phpunit --verbose --coverage-clover=coverage.clover


### PR DESCRIPTION
Some improvements for Travis, which will speed it up a bit.

Also adds tests for 7.1 and tests the lowest version of the dependencies, eg. Symfony 2.7 instead of 3

- Cache Composer files
- Add php 7.1
- Install lowest + normal dependencies