### PR TITLE
Ensure correct ordering of styles

### DIFF
--- a/src/Css/Rule/Processor.php
+++ b/src/Css/Rule/Processor.php
@@ -129,6 +129,8 @@ class Processor
             $order++;
         }
 
+        usort($objects, ['self', 'sortOnSpecificity']);
+
         return $objects;
     }
 

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -63,18 +63,21 @@ class CssToInlineStyles
         }
 
         $cssProperties = array();
+        $cssInlineProperties = array();
         $inlineProperties = $this->getInlineStyles($element);
 
-        foreach ($properties as $property) {
-            $cssProperties[$property->getName()] = $property;
+        foreach ($inlineProperties as $property) {
+            $cssInlineProperties[$property->getName()] = $property;
         }
 
-        foreach ($inlineProperties as $property) {
-            $cssProperties[$property->getName()] = $property;
+        foreach ($properties as $property) {
+            if (!isset($cssInlineProperties[$property->getName()])) {
+                $cssProperties[$property->getName()] = $property;
+            }
         }
 
         $rules = array();
-        foreach ($cssProperties as $property) {
+        foreach (array_merge($cssProperties, $cssInlineProperties) as $property) {
             $rules[] = $property->toString();
         }
         $element->setAttribute('style', implode(' ', $rules));

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -65,16 +65,12 @@ class CssToInlineStyles
         $cssProperties = array();
         $inlineProperties = $this->getInlineStyles($element);
 
-        if (!empty($inlineProperties)) {
-            foreach ($inlineProperties as $property) {
-                $cssProperties[$property->getName()] = $property;
-            }
+        foreach ($properties as $property) {
+            $cssProperties[$property->getName()] = $property;
         }
 
-        foreach ($properties as $property) {
-            if (!isset($cssProperties[$property->getName()])) {
-                $cssProperties[$property->getName()] = $property;
-            }
+        foreach ($inlineProperties as $property) {
+            $cssProperties[$property->getName()] = $property;
         }
 
         $rules = array();

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -151,6 +151,8 @@ EOF;
         $html = <<<EOF
 <a class="one" id="ONE" style="padding: 100px;">
   <img class="two" id="TWO">
+  <img class="three" id="THREE">
+  <img class="four" id="FOUR" style="margin-left: 100px;">
 </a>
 EOF;
         $css = <<<EOF
@@ -178,10 +180,22 @@ a img {
 img {
   border: 2px solid green;
 }
+
+#THREE {
+  padding-left: 10px;
+}
+
+.three {
+  padding: 100px;
+}
+
+.four {
+  margin: 10px;
+}
 EOF;
         $expected = <<<EOF
 <a class="one" id="ONE" style="padding: 100px; border: 1px solid red; margin: 10px; width: 20px !important;">
-  <img class="two" id="TWO" style="border: none;"></a>
+  <img class="two" id="TWO" style="border: none;"><img class="three" id="THREE" style="border: none; padding: 100px; padding-left: 10px;"><img class="four" id="FOUR" style="margin-left: 100px; border: none; margin: 10px;"></a>
 EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -77,7 +77,7 @@ class CssToInlineStylesTest extends \PHPUnit_Framework_TestCase
         $document->appendChild($inlineElement);
 
         $this->assertEquals(
-            '<a style="color: green; padding: 5px;">foo</a>',
+            '<a style="padding: 5px; color: green;">foo</a>',
             trim($document->saveHTML())
         );
     }

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -203,8 +203,8 @@ img {
 }
 EOF;
         $expected = <<<EOF
-<a class="one" id="ONE" style="padding: 100px; border: 1px solid red; margin: 10px; width: 20px !important;">
-  <img class="two" id="TWO" style="border: none;"><img class="three" id="THREE" style="border: none; padding: 100px; padding-left: 10px;"><img class="four" id="FOUR" style="margin-left: 100px; border: none; margin: 10px;"><img class="five" id="FIVE" style="border: none; padding-left: 10px; padding: 100px;"></a>
+<a class="one" id="ONE" style="border: 1px solid red; margin: 10px; width: 20px !important; padding: 100px;">
+  <img class="two" id="TWO" style="border: none;"><img class="three" id="THREE" style="border: none; padding: 100px; padding-left: 10px;"><img class="four" id="FOUR" style="border: none; margin: 10px; margin-left: 100px;"><img class="five" id="FIVE" style="border: none; padding-left: 10px; padding: 100px;"></a>
 EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -153,6 +153,7 @@ EOF;
   <img class="two" id="TWO">
   <img class="three" id="THREE">
   <img class="four" id="FOUR" style="margin-left: 100px;">
+  <img class="five" id="FIVE" style="padding-left: 10px; padding: 100px;">
 </a>
 EOF;
         $css = <<<EOF
@@ -192,10 +193,18 @@ img {
 .four {
   margin: 10px;
 }
+
+.five {
+  padding: 15px;
+}
+
+#FIVE {
+  padding-left: 20px;
+}
 EOF;
         $expected = <<<EOF
 <a class="one" id="ONE" style="padding: 100px; border: 1px solid red; margin: 10px; width: 20px !important;">
-  <img class="two" id="TWO" style="border: none;"><img class="three" id="THREE" style="border: none; padding: 100px; padding-left: 10px;"><img class="four" id="FOUR" style="margin-left: 100px; border: none; margin: 10px;"></a>
+  <img class="two" id="TWO" style="border: none;"><img class="three" id="THREE" style="border: none; padding: 100px; padding-left: 10px;"><img class="four" id="FOUR" style="margin-left: 100px; border: none; margin: 10px;"><img class="five" id="FIVE" style="border: none; padding-left: 10px; padding: 100px;"></a>
 EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }


### PR DESCRIPTION
When a property can be set using different names, such as `padding` and `padding-left`, the inlined styles were not always correctly ordered.

Examples:

    <style type="text/css">
    span.test {
       background-color: blue;
    }
    span {
       background: red;
    }
    </style>
    <span class="test">This should be blue</span>

Will result in `<span style="background-color: blue; background: red;">This should be blue</span>` even though `background-color: blue;` has higher specificity than `background: red;`. This issue is fixed by sorting all rules by specificity instead of order of appearance: https://github.com/tijsverkoyen/CssToInlineStyles/commit/bdf1c2e623ccfcf4de2d6d30264687632715228d

    <style type="text/css">
    span {
       background: red;
    }
    </style>
    <span style="background-color: blue;">This should be blue</span>

Will result in `<span style="background-color: blue; background: red;">This should be blue</span>` since the styles being inlined are positioned after the styles that were already inline. This issue is fixed by positioning the styles that were already inline last: https://github.com/tijsverkoyen/CssToInlineStyles/commit/716da4a48b2d76b05c4069e41fd03433e39c3633, https://github.com/tijsverkoyen/CssToInlineStyles/commit/e7d45286a41bd43ae6acba96e9c5412218c8c6e3
