### PR TITLE
Better ordering of style rules and properties

### DIFF
--- a/src/Css/Rule/Processor.php
+++ b/src/Css/Rule/Processor.php
@@ -133,13 +133,14 @@ class Processor
     }
 
     /**
-     * Sort an array on the specificity element
+     * Sort an array on the specificity element in an ascending way
+     * Lower specificity will be sorted to the beginning of the array
      *
      * @return int
      * @param  Rule $e1 The first element.
      * @param  Rule $e2 The second element.
      */
-    private static function sortOnSpecificity(Rule $e1, Rule $e2)
+    public static function sortOnSpecificity(Rule $e1, Rule $e2)
     {
         $e1Specificity = $e1->getSpecificity();
         $value = $e1Specificity->compareTo($e2->getSpecificity());

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -64,22 +64,20 @@ class CssToInlineStyles
         }
 
         $cssProperties = array();
-        $inlineProperties = $this->getInlineStyles($element);
+        $inlineProperties = array();
 
-        if (!empty($inlineProperties)) {
-            foreach ($inlineProperties as $property) {
-                $cssProperties[$property->getName()] = $property;
-            }
+        foreach ($this->getInlineStyles($element) as $property) {
+            $inlineProperties[$property->getName()] = $property;
         }
 
         foreach ($properties as $property) {
-            if (!isset($cssProperties[$property->getName()])) {
+            if (!isset($inlineProperties[$property->getName()])) {
                 $cssProperties[$property->getName()] = $property;
             }
         }
 
         $rules = array();
-        foreach ($cssProperties as $property) {
+        foreach (array_merge($cssProperties, $inlineProperties) as $property) {
             $rules[] = $property->toString();
         }
         $element->setAttribute('style', implode(' ', $rules));

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -7,6 +7,7 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
 use Symfony\Component\CssSelector\Exception\ExceptionInterface;
 use TijsVerkoyen\CssToInlineStyles\Css\Processor;
 use TijsVerkoyen\CssToInlineStyles\Css\Property\Processor as PropertyProcessor;
+use TijsVerkoyen\CssToInlineStyles\Css\Rule\Processor as RuleProcessor;
 use TijsVerkoyen\CssToInlineStyles\Css\Rule\Rule;
 
 class CssToInlineStyles
@@ -155,6 +156,9 @@ class CssToInlineStyles
         }
 
         $xPath = new \DOMXPath($document);
+
+        usort($rules, array(RuleProcessor::class, 'sortOnSpecificity'));
+
         foreach ($rules as $rule) {
             try {
                 if (null !== $this->cssConverter) {
@@ -227,20 +231,19 @@ class CssToInlineStyles
             if (isset($cssProperties[$property->getName()])) {
                 $existingProperty = $cssProperties[$property->getName()];
 
-                if (
-                    ($existingProperty->isImportant() && $property->isImportant()) &&
-                    ($existingProperty->getOriginalSpecificity()->compareTo($property->getOriginalSpecificity()) <= 0)
-                ) {
-                    // if both the properties are important we should use the specificity
-                    $cssProperties[$property->getName()] = $property;
-                } elseif (!$existingProperty->isImportant() && $property->isImportant()) {
-                    // if the existing property is not important but the new one is, it should be overruled
-                    $cssProperties[$property->getName()] = $property;
-                } elseif (
-                    !$existingProperty->isImportant() &&
-                    ($existingProperty->getOriginalSpecificity()->compareTo($property->getOriginalSpecificity()) <= 0)
-                ) {
-                    // if the existing property is not important we should check the specificity
+                //skip check to overrule if existing property is important and current is not
+                if ($existingProperty->isImportant() && !$property->isImportant()) {
+                    continue;
+                }
+
+                //overrule if current property is important and existing is not, else check specificity
+                $overrule = !$existingProperty->isImportant() && $property->isImportant();
+                if (!$overrule) {
+                    $overrule = $existingProperty->getOriginalSpecificity()->compareTo($property->getOriginalSpecificity()) <= 0;
+                }
+
+                if ($overrule) {
+                    unset($cssProperties[$property->getName()]);
                     $cssProperties[$property->getName()] = $property;
                 }
             } else {

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -154,21 +154,32 @@ EOF;
 </a>
 EOF;
         $css = <<<EOF
+a.one  {
+  border-bottom: 2px;
+  height: 20px;
+}
+
 a {
   border: 1px solid red;
   padding: 10px;
   margin: 20px;
   width: 10px !important;
+  height: 10px;
 }
 
 .one {
   padding: 15px;
   width: 20px !important;
+  height: 5px;
 }
 
 #ONE {
   margin: 10px;
   width: 30px;
+}
+
+img {
+  padding: 0;
 }
 
 a img {
@@ -177,11 +188,16 @@ a img {
 
 img {
   border: 2px solid green;
+  padding-bottom: 20px;
+}
+
+img {
+  padding: 0;
 }
 EOF;
         $expected = <<<EOF
-<a class="one" id="ONE" style="padding: 100px; border: 1px solid red; margin: 10px; width: 20px !important;">
-  <img class="two" id="TWO" style="border: none;"></a>
+<a class="one" id="ONE" style="padding: 100px; border: 1px solid red; width: 20px !important; border-bottom: 2px; height: 20px; margin: 10px;">
+  <img class="two" id="TWO" style="padding-bottom: 20px; padding: 0; border: none;"></a>
 EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -66,18 +66,19 @@ class CssToInlineStylesTest extends \PHPUnit_Framework_TestCase
     {
         $document = new \DOMDocument();
         $element = $document->createElement('a', 'foo');
-        $element->setAttribute('style', 'color: green;');
+        $element->setAttribute('style', 'color: green; border: 1px;');
         $inlineElement = $this->cssToInlineStyles->inlineCssOnElement(
             $element,
             array(
-                new Property('padding', '5px'),
+                new Property('border-bottom', '5px'),
+                new Property('border', '2px'),
             )
         );
 
         $document->appendChild($inlineElement);
 
         $this->assertEquals(
-            '<a style="color: green; padding: 5px;">foo</a>',
+            '<a style="border-bottom: 5px; color: green; border: 1px;">foo</a>',
             trim($document->saveHTML())
         );
     }
@@ -150,7 +151,7 @@ EOF;
     {
         $html = <<<EOF
 <a class="one" id="ONE" style="padding: 100px;">
-  <img class="two" id="TWO">
+  <img class="two" id="TWO" style="padding-top: 30px;">
 </a>
 EOF;
         $css = <<<EOF
@@ -196,8 +197,8 @@ img {
 }
 EOF;
         $expected = <<<EOF
-<a class="one" id="ONE" style="padding: 100px; border: 1px solid red; width: 20px !important; border-bottom: 2px; height: 20px; margin: 10px;">
-  <img class="two" id="TWO" style="padding-bottom: 20px; padding: 0; border: none;"></a>
+<a class="one" id="ONE" style="border: 1px solid red; width: 20px !important; border-bottom: 2px; height: 20px; margin: 10px; padding: 100px;">
+  <img class="two" id="TWO" style="padding-bottom: 20px; padding: 0; border: none; padding-top: 30px;"></a>
 EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }


### PR DESCRIPTION
This PR solves the same issues as #159 and #155, and more.
It assigns all issues reported in https://github.com/tijsverkoyen/CssToInlineStyles/issues/140.

This pr too takes priority into account by sorting the rules via the already available method, but sorting happens later (when you need it) when rules are inserted, not when they are parsed and collected.

When processing properties it does not just overwrite the properties but it unsets and adds them.
This ensures that the order is correct and the css like the one below is processed correctly too:
```css
td  {
    padding: 0;
}

td  {
    padding-bottom: 20px;
}

td  {
    padding: 0;
}
```

The specificity tests are updated to reflect the changes made with ordering the rules and properties.
It also tests all the different uses cases mentioned in https://github.com/tijsverkoyen/CssToInlineStyles/issues/140.
