### PR TITLE
Remove styles that are inside html comments

### DIFF
--- a/src/Css/Processor.php
+++ b/src/Css/Processor.php
@@ -33,7 +33,8 @@ class Processor
     {
         $css = '';
         $matches = array();
-        preg_match_all('|<style(?:\s.*)?>(.*)</style>|isU', $html, $matches);
+        $htmlNoComments = preg_replace('|<!--.*?-->|s', '', $html);
+        preg_match_all('|<style(?:\s.*)?>(.*)</style>|isU', $htmlNoComments, $matches);
 
         if (!empty($matches[1])) {
             foreach ($matches[1] as $match) {

--- a/tests/Css/ProcessorTest.php
+++ b/tests/Css/ProcessorTest.php
@@ -232,4 +232,36 @@ HTML
         );
 
     }
+
+    public function testStyleTagsInCommentInHtml()
+    {
+        $expected = 'p { color: #F00; }' . "\n";
+        $this->assertEquals(
+            $expected,
+            $this->processor->getCssFromStyleTags(
+                <<<EOF
+                    <html>
+    <head>
+        <style>
+            p { color: #F00; }
+        </style>
+<!--
+        <style>
+            p { color: #0F0; }
+        </style>
+-->
+<!--[if mso]>
+        <style>
+            p { color: #00F; }
+        </style>
+<![endif]-->
+    </head>
+    <body>
+        <p>foo</p>
+    </body>
+    </html>
+EOF
+            )
+        );
+    }
 }


### PR DESCRIPTION
When the <style> block is inside a html comment, it's contents should
not be inlined.