### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "symfony/css-selector": "^2.7|~3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.8|5.1.*"
+    "phpunit/phpunit": "~4.8.35|~5.7"
   },
   "autoload": {
     "psr-4": {

--- a/tests/Css/ProcessorTest.php
+++ b/tests/Css/ProcessorTest.php
@@ -4,8 +4,9 @@
 namespace TijsVerkoyen\CssToInlineStyles\Tests\Css;
 
 use TijsVerkoyen\CssToInlineStyles\Css\Processor;
+use PHPUnit\Framework\TestCase;
 
-class ProcessorTest extends \PHPUnit_Framework_TestCase
+class ProcessorTest extends TestCase
 {
     /**
      * @var Processor

--- a/tests/Css/Property/ProcessorTest.php
+++ b/tests/Css/Property/ProcessorTest.php
@@ -4,8 +4,9 @@ namespace TijsVerkoyen\CssToInlineStyles\Tests\Css\Property;
 
 use TijsVerkoyen\CssToInlineStyles\Css\Property\Processor;
 use TijsVerkoyen\CssToInlineStyles\Css\Property\Property;
+use PHPUnit\Framework\TestCase;
 
-class ProcessorTest extends \PHPUnit_Framework_TestCase
+class ProcessorTest extends TestCase
 {
     /**
      * @var Processor

--- a/tests/Css/Property/PropertyTest.php
+++ b/tests/Css/Property/PropertyTest.php
@@ -3,8 +3,9 @@
 namespace TijsVerkoyen\CssToInlineStyles\Tests\Css\Property;
 
 use TijsVerkoyen\CssToInlineStyles\Css\Property\Property;
+use PHPUnit\Framework\TestCase;
 
-class PropertyTest extends \PHPUnit_Framework_TestCase
+class PropertyTest extends TestCase
 {
     public function testGetters()
     {

--- a/tests/Css/Rule/ProcessorTest.php
+++ b/tests/Css/Rule/ProcessorTest.php
@@ -4,8 +4,9 @@ namespace TijsVerkoyen\CssToInlineStyles\Tests\Css\Rule;
 
 use Symfony\Component\CssSelector\Node\Specificity;
 use TijsVerkoyen\CssToInlineStyles\Css\Rule\Processor;
+use PHPUnit\Framework\TestCase;
 
-class ProcessorTest extends \PHPUnit_Framework_TestCase
+class ProcessorTest extends TestCase
 {
     /**
      * @var Processor

--- a/tests/Css/Rule/RuleTest.php
+++ b/tests/Css/Rule/RuleTest.php
@@ -5,8 +5,9 @@ namespace TijsVerkoyen\CssToInlineStyles\Tests\Css\Rule;
 use TijsVerkoyen\CssToInlineStyles\Css\Property\Property;
 use TijsVerkoyen\CssToInlineStyles\Css\Rule\Rule;
 use Symfony\Component\CssSelector\Node\Specificity;
+use PHPUnit\Framework\TestCase;
 
-class PropertyTest extends \PHPUnit_Framework_TestCase
+class PropertyTest extends TestCase
 {
     public function testGetters()
     {

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -4,8 +4,9 @@ namespace TijsVerkoyen\CssToInlineStyles\tests;
 
 use TijsVerkoyen\CssToInlineStyles\Css\Property\Property;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
+use PHPUnit\Framework\TestCase;
 
-class CssToInlineStylesTest extends \PHPUnit_Framework_TestCase
+class CssToInlineStylesTest extends TestCase
 {
     /**
      * @var CssToInlineStyles


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`~5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.