### PR TITLE
Handle unparseable files by simply returning the markup

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -34,6 +34,9 @@ class CssToInlineStyles
     public function convert($html, $css = null)
     {
         $document = $this->createDomDocumentFromHtml($html);
+        if ($document->documentElement === null) {
+            return $html;
+        }
         $processor = new Processor();
 
         // get all styles from the style-tags

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -255,6 +255,14 @@ EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }
 
+    public function testOnlyDoctype()
+    {
+        $html = '<!DOCTYPE html>';
+
+        $this->assertEquals($html, $this->cssToInlineStyles->convert($html));
+    }
+
+
     private function assertCorrectConversion($expected, $html, $css = null)
     {
         $this->assertEquals(


### PR DESCRIPTION
Without this in place, this results in an error: TypeError: Argument 1
passed to DOMNode::removeChild() must be an instance of DOMNode, null
given

This used to work in the older versions (1.x)

I know this is a bit broken, but it's a regression and we sadly don't have control over all of the weird input our users put into it.