### PR TITLE
Allow Symfony 5 to unlock the CI of symfony/symfony

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 cache:
   directories:
     - $HOME/.composer/cache/files
@@ -17,9 +19,8 @@ matrix:
       env: setup=lowest
     - php: 7.1
     - php: 7.2
-    - php: hhvm
-  allow_failures:
-    - php: hhvm
+    - php: 7.3
+    - php: 7.4snapshot
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^5.5 || ^7.0",
-    "symfony/css-selector": "^2.7 || ^3.0 || ^4.0"
+    "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"


### PR DESCRIPTION
A quick merge would be greatly appreciated as the CI of symfony/symfony needs this change to be green. Thanks in advance!

see e.g. https://travis-ci.org/symfony/symfony/jobs/587127531