### PR TITLE
Insert media queries to style tag in the head of the document when the sources css makes use of them.

### DIFF
--- a/src/Css/Processor.php
+++ b/src/Css/Processor.php
@@ -25,6 +25,21 @@ class Processor
     }
 
     /**
+     * Get all media queries from the given css string.
+     *
+     * @param $css
+     * @param array $existingMediaQueries
+     * @return array
+     */
+    public function getMediaQueries(string $css, array $existingMediaQueries = array()) {
+        $matches = [];
+        if ( preg_match_all( '/@media [^{]*+{([^{}]++|{[^{}]*+})*+}/', $css, $matches ) ) {
+            return array_merge($existingMediaQueries, $matches[0]);
+        }
+        return $existingMediaQueries;
+    }
+
+    /**
      * Get the CSS from the style-tags in the given HTML-string
      *
      * @param string $html

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -214,8 +214,8 @@ class CssToInlineStyles
         if ( ! sizeof($mediaQueries) ) return $document;
         $style = $document->createElement('style', implode($mediaQueries));
         if ( $style ) {
-            $body = $document->getElementsByTagName('body')->item(0);
-            $body->appendChild($style);
+            $head = $document->getElementsByTagName('head')->item(0);
+            $head->appendChild($style);
         }
         return $document;
     }

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -215,7 +215,15 @@ class CssToInlineStyles
         $style = $document->createElement('style', implode($mediaQueries));
         if ( $style ) {
             $head = $document->getElementsByTagName('head')->item(0);
-            $head->appendChild($style);
+            // Partials aren't supported (missing head tag). But lets play nice.
+            if ( $head !== null ) {
+                $head->appendChild($style);
+            } else {
+                $docNode = $document->documentElement;
+                $head = $document->createElement('head');
+                $head->appendChild($style);
+                $docNode->appendChild($head);
+            }
         }
         return $document;
     }

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -108,15 +108,18 @@ EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }
 
-    public function testMediaQueryExtraction()
+    public function testMediaQueryNoHeadTag()
     {
         $html = '<div></div>';
         $css = 'div { display: none; }; @media screen and (max-width: 600px) { div {display: block} }';
-        $expected = implode("\n", [
-            '<div style="display: none;"></div>',
-            '<style>@media screen and (max-width: 600px) { div {display: block} }</style>'
-        ]);
-        $this->assertCorrectConversion($expected, $html, $css);
+        $this->assertHeadHasMediaQuery($html, $css);
+    }
+
+    public function testAddMediaQueriesToHead()
+    {
+        $html = '<html><head></head><div></div></html>';
+        $css = 'div { display: none; }; @media screen and (max-width: 600px) { div {display: block} }';
+        $this->assertHeadHasMediaQuery($html, $css);
     }
 
     public function testSimpleCssSelector()
@@ -266,6 +269,16 @@ EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }
 
+    private function assertHeadHasMediaQuery($html, $css = null)
+    {
+        $this->assertContains(
+            '@media',
+            $this->getHeadContent(
+                $this->cssToInlineStyles->convert($html, $css)
+            )
+        );
+    }
+
     private function assertCorrectConversion($expected, $html, $css = null)
     {
         $this->assertEquals(
@@ -283,6 +296,18 @@ EOF;
 
         if (!isset($matches[1])) {
             return null;
+        }
+
+        return trim($matches[1]);
+    }
+
+    private function getHeadContent($html)
+    {
+        $matches = array();
+        preg_match('|<head>(.*)</head>|ims', $html, $matches);
+
+        if (!isset($matches[1])) {
+            return '';
         }
 
         return trim($matches[1]);

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -108,6 +108,17 @@ EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }
 
+    public function testMediaQueryExtraction()
+    {
+        $html = '<div></div>';
+        $css = 'div { display: none; }; @media screen and (max-width: 600px) { div {display: block} }';
+        $expected = implode("\n", [
+            '<div style="display: none;"></div>',
+            '<style>@media screen and (max-width: 600px) { div {display: block} }</style>'
+        ]);
+        $this->assertCorrectConversion($expected, $html, $css);
+    }
+
     public function testSimpleCssSelector()
     {
         $html = '<a class="test-class">nodeContent</a>';


### PR DESCRIPTION
css media queries were filtered out (which makes sense as they're not supported as inline style), now that more and more clients support style tags in the head it makes sense to include them their when the sources css contains them. 