### PR TITLE
Add LIBXML_NOBLANKS to make the output same on Linux and Windows

### DIFF
--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -113,7 +113,7 @@ class CssToInlineStyles
     {
         $document = new \DOMDocument('1.0', 'UTF-8');
         $internalErrors = libxml_use_internal_errors(true);
-        $document->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        $document->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'), LIBXML_NOBLANKS);
         libxml_use_internal_errors($internalErrors);
         $document->formatOutput = true;
 

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -159,6 +159,20 @@ EOF;
         $this->assertCorrectConversion($expected, $html);
     }
 
+    public function testLinuxWindowsOutputDifference()
+    {
+        $html = <<<EOF
+<a>
+  <img>
+</a>
+EOF;
+        $expected = <<<EOF
+<a>
+  <img></a>
+EOF;
+        $this->assertCorrectConversion($expected, $html, '');
+    }
+
     public function testSpecificity()
     {
         $html = <<<EOF
@@ -210,8 +224,7 @@ img {
 EOF;
         $expected = <<<EOF
 <a class="one" id="ONE" style="border: 1px solid red; width: 20px !important; border-bottom: 2px; height: 20px; margin: 10px; padding: 100px;">
-  <img class="two" id="TWO" style="padding-bottom: 20px; padding: 0; border: none; padding-top: 30px;">
-</a>
+  <img class="two" id="TWO" style="padding-bottom: 20px; padding: 0; border: none; padding-top: 30px;"></a>
 EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }


### PR DESCRIPTION
We are using this library through Symfony to inline CSS in e-mails. We are also
using snapshot testing for rendered e-mails templates and I discovered that the
output of this library differs between Windows (dev machine) and Linux (CI).

I tried running the test suite on Windows and the test
`CssToInlineStylesTest::testSpecificity()` fails because of whitespace difference:
on Windows there is an extra `\n` before the closing `</a>` in the output.

I tried loading and saving a a super-simplified HTML `<a>\n<img>\n</a>`
through the DOMDocument without this library but with the same settings
and a similar thing happen (newline before </a> is present on Windows but missing
on Linux).

When the option `LIBXML_NOBLANKS` is added to `loadHTML()` the output no longer
differs between the Windows and Linux.

To be honest, I'm not sure if this is a proper fix.
It should be rather considered a bug report with a workaround.