### PR TITLE
Add masterminds/html5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,11 @@
     "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^7.5"
+    "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^7.5",
+    "masterminds/html5": "^2.7"
+  },
+  "suggest": {
+    "masterminds/html5": "To use a HTML5 parser instead of native DOM parser."
   },
   "autoload": {
     "psr-4": {

--- a/tests/HTML5ParserTest.php
+++ b/tests/HTML5ParserTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace TijsVerkoyen\CssToInlineStyles\tests;
+
+use PHPUnit\Framework\TestCase;
+use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
+
+class HTML5ParserTest extends TestCase
+{
+    /**
+     * @var CssToInlineStyles
+     */
+    protected $cssToInlineStyles;
+
+    /**
+     * @before
+     */
+    protected function prepare()
+    {
+        $this->cssToInlineStyles = new CssToInlineStyles(true);
+    }
+
+    /**
+     * @after
+     */
+    protected function clear()
+    {
+        $this->cssToInlineStyles = null;
+    }
+
+    public function testBasicHtml()
+    {
+        $html = '<!doctype html><html><head><style>body{color:blue}</style></head><body><p>foo</p></body></html>';
+        $css = 'p { color: red; }';
+        $expected = <<<EOF
+<!doctype html>
+<html><head><style>body{color:blue}</style></head><body style="color: blue;"><p style="color: red;">foo</p></body></html>
+EOF;
+
+        $this->assertEquals($expected, $this->cssToInlineStyles->convert($html, $css));
+    }
+}


### PR DESCRIPTION
This PR adds optional usage of `masterminds/html5` similar to the implementation in `symfony/dom-crawler`. This resolves some quirks when saving HTML documents with `DOMDocument` for example an anchor wrapping a table `<a><table></table></a>` becomes `<table></table><a></a>`

Opt-in usage - pass `true` to the constructor argument. This differs to `symfony/dom-crawler` for the sake of backwards compatibility i.e. users who already have `masterminds/html5` as a project dependency
```php
$cssToInlineStyles = new CssToInlineStyles(true);
```

Closes #195