### PR TITLE
Fix parsing of HTML comments within style elements

### DIFF
--- a/tests/Css/ProcessorTest.php
+++ b/tests/Css/ProcessorTest.php
@@ -265,4 +265,21 @@ EOF
             )
         );
     }
+
+    public function testHtmlCommentsInStyle()
+    {
+        $expected = 'p{color:blue}' . "\n";
+        $this->assertEquals(
+            $expected,
+            $this->processor->getCssFromStyleTags(
+                <<<EOF
+<!doctype html>
+<html>
+<head><style><!-- p{color:blue} --></style></head>
+<body><p>foo</p></body>
+</html>
+EOF
+            )
+        );
+    }
 }


### PR DESCRIPTION
Relates to https://github.com/tijsverkoyen/CssToInlineStyles/pull/164

At the moment the below contents of the style are removed due to the HTML comment. This structure is common in received emails.

```html
<style><!-- p {color: blue} --></style>
```

> when using the `<style>` element, you may use `<!-- -->` to hide CSS from older browsers

https://developer.mozilla.org/en-US/docs/Web/CSS/Comments#notes

It's valid per https://drafts.csswg.org/css-syntax see `CDC-Token` when parsing a stylesheet.