### PR TITLE
Allow Symfony 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": "^5.5 || ^7.0 || ^8.0",
     "ext-dom": "*",
     "ext-libxml": "*",
-    "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0"
+    "symfony/css-selector": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^7.5"


### PR DESCRIPTION
Staring yesterday you can install Symfony 6.0 (if you allow unstable dependencies). 

I know Symfony 6.0 is not released yet (it will be released in November 2021). But since this package is required by some CI jobs of symfony/symfony I would appreciate if this PR was merged. 