### PR TITLE
Add the code coverage filtering config in the PHPUnit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,4 +14,10 @@
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
This allows running PHPUnit with code coverage enabled.
In modern PHPUnit versions, the filter config is mandatory otherwise the code coverage is skipped.