### PR TITLE
Mark .github directory as ignored for exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@
 /phpunit.xml.dist export-ignore
 /CHANGELOG.md export-ignore
 /README.md export-ignore
+/.github export-ignore


### PR DESCRIPTION
Currently the github workflow is present in the published package.