### PR TITLE
Ensure file name matches class name

### DIFF
--- a/tests/Css/Rule/RuleTest.php
+++ b/tests/Css/Rule/RuleTest.php
@@ -7,7 +7,7 @@ use TijsVerkoyen\CssToInlineStyles\Css\Rule\Rule;
 use Symfony\Component\CssSelector\Node\Specificity;
 use PHPUnit\Framework\TestCase;
 
-class PropertyTest extends TestCase
+class RuleTest extends TestCase
 {
     public function testGetters()
     {


### PR DESCRIPTION
Otherwise, the test suite fails with recent version of PHPUnit (10).