### PR TITLE
Bump the min PHP version to PHP 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         operating-system: [ ubuntu-latest ]
         composer_flags: [ '' ]
         include:
-          - php: '7.2'
+          - php: '7.4'
             composer_flags: '--prefer-lowest'
             operating-system: ubuntu-latest
           - php: '8.0'

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": "^7.2.5 || ^8.0",
+    "php": "^7.4 || ^8.0",
     "ext-dom": "*",
     "ext-libxml": "*",
     "symfony/css-selector": "^5.4 || ^6.0 || ^7.0"


### PR DESCRIPTION
Starting to work on adding phpstan in this project, I figured out that it would be a lot simpler to setup if our min PHP version was compatible with the min version required by phpstan (so that we can use a normal `require-dev` to install it).
As we have an unreleased version bump already (from PHP 5.3 to PHP 7.2.5), I'm updating it to bump to 7.4 instead (which is still outside the list of maintained PHP versions, but still represents 5% of installs in the packagist stats so I'm keeping it as it does not annoy me to keep support for it).