### PR TITLE
Adapt tests to conform with HTML5

### DIFF
--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -266,41 +266,41 @@ EOF;
 
     public function testConversionAsciiRegular(): void
     {
-        $html = '~';
+        $html = '<p>~</p>';
         $css = '';
-        $expected = "<p>{$html}</p>";
+        $expected = $html;
         $this->assertCorrectConversion($expected, $html, $css);
     }
 
     public function testConversionAsciiDelete(): void
     {
-        $html = "\u{007F}";
+        $html = "<p>\u{007F}</p>";
         $css = '';
-        $expected = "<p>{$html}</p>";
+        $expected = $html;
         $this->assertCorrectConversion($expected, $html, $css);
     }
 
     public function testConversionLowestCodepoint(): void
     {
-        $html = "\u{0080}";
+        $html = "<p>\u{0080}</p>";
         $css = '';
-        $expected = "<p>{$html}</p>";
+        $expected = $html;
         $this->assertCorrectConversion($expected, $html, $css);
     }
 
     public function testConversionHighestCodepoint(): void
     {
-        $html = "\u{10FFFF}";
+        $html = "<p>\u{10FFFF}</p>";
         $css = '';
-        $expected = "<p>{$html}</p>";
+        $expected = $html;
         $this->assertCorrectConversion($expected, $html, $css);
     }
 
     public function testMB4character(): void
     {
-        $html = '🇳🇱';
+        $html = '<p>🇳🇱</p>';
         $css = '';
-        $expected = "<p>{$html}</p>";
+        $expected = $html;
         $this->assertCorrectConversion($expected, $html, $css);
     }
 


### PR DESCRIPTION
When php is compiled with libxml2 > 2.14, the loadHTML functionality will use HTML5 standards, which cause the <p> tags in the tests not to be created. Passing the <p> as input ensures both the old and new libxml2 convert it the same way, and keeps the actual test purpose (which is to check encoding)

This is not a full fix to #253 , because `testConversionLowestCodepoint` is still failing with the new libxml2, and I'm not sure how upstream wants to fix that. In Ubuntu I have [commented the test to unblock packaging](https://code.launchpad.net/~rr/ubuntu/+source/php-tijsverkoyen-css-to-inline-styles/+git/php-tijsverkoyen-css-to-inline-styles/+merge/490202) meanwhile.