### PR TITLE
Improve performance

### DIFF
--- a/src/Css/Rule/Processor.php
+++ b/src/Css/Rule/Processor.php
@@ -63,13 +63,15 @@ class Processor
 
         foreach ($selectors as $selector) {
             $selector = trim($selector);
-            $specificity = $this->calculateSpecificityBasedOnASelector($selector);
+            [$a, $b, $c] = $this->countSpecificity($selector);
+            $specificity = new Specificity($a, $b, $c);
 
             $rules[] = new Rule(
                 $selector,
                 $propertiesProcessor->convertArrayToObjects($properties, $specificity),
                 $specificity,
-                $originalOrder
+                $originalOrder,
+                [$a, $b, $c]
             );
         }
 
@@ -78,15 +80,29 @@ class Processor
 
     /**
      * Calculates the specificity based on a CSS Selector string,
-     * Based on the patterns from premailer/css_parser by Alex Dunae
-     *
-     * @see https://github.com/premailer/css_parser/blob/master/lib/css_parser/regexps.rb
      *
      * @param string $selector
      *
      * @return Specificity
      */
     public function calculateSpecificityBasedOnASelector($selector)
+    {
+        [$a, $b, $c] = $this->countSpecificity($selector);
+
+        return new Specificity($a, $b, $c);
+    }
+
+    /**
+     * Counts the specificity components (a, b, c) of a CSS Selector string,
+     * Based on the patterns from premailer/css_parser by Alex Dunae
+     *
+     * @see https://github.com/premailer/css_parser/blob/master/lib/css_parser/regexps.rb
+     *
+     * @param string $selector
+     *
+     * @return int[] the [a, b, c] specificity components of the selector
+     */
+    private function countSpecificity($selector)
     {
         $idSelectorCount = preg_match_all("/  \#/ix", $selector, $matches);
         $classAttributesPseudoClassesSelectorsPattern = "  (\.[\w]+)                     # classes
@@ -121,11 +137,11 @@ class Processor
             throw new \RuntimeException('Failed to calculate specificity based on selector.');
         }
 
-        return new Specificity(
+        return [
             $idSelectorCount,
             $classAttributesPseudoClassesSelectorCount,
-            $typePseudoElementsSelectorCount
-        );
+            $typePseudoElementsSelectorCount,
+        ];
     }
 
     /**

--- a/src/Css/Rule/Rule.php
+++ b/src/Css/Rule/Rule.php
@@ -28,19 +28,26 @@ final class Rule
     private $order;
 
     /**
+     * @var int[]|null the [a, b, c] specificity components
+     */
+    private $specificityValues;
+
+    /**
      * Rule constructor.
      *
      * @param string      $selector
      * @param Property[]  $properties
      * @param Specificity $specificity
      * @param int         $order
+     * @param int[]|null  $specificityValues the [a, b, c] specificity components
      */
-    public function __construct($selector, array $properties, Specificity $specificity, $order)
+    public function __construct($selector, array $properties, Specificity $specificity, $order, ?array $specificityValues = null)
     {
         $this->selector = $selector;
         $this->properties = $properties;
         $this->specificity = $specificity;
         $this->order = $order;
+        $this->specificityValues = $specificityValues;
     }
 
     /**
@@ -81,5 +88,60 @@ final class Rule
     public function getOrder()
     {
         return $this->order;
+    }
+
+    /**
+     * Get the number of ID selectors (the "a" specificity component)
+     *
+     * @return int
+     */
+    public function getSpecificityA()
+    {
+        return $this->resolveSpecificityValues()[0];
+    }
+
+    /**
+     * Get the number of class, attribute and pseudo-class selectors
+     * (the "b" specificity component)
+     *
+     * @return int
+     */
+    public function getSpecificityB()
+    {
+        return $this->resolveSpecificityValues()[1];
+    }
+
+    /**
+     * Get the number of type and pseudo-element selectors
+     * (the "c" specificity component)
+     *
+     * @return int
+     */
+    public function getSpecificityC()
+    {
+        return $this->resolveSpecificityValues()[2];
+    }
+
+    /**
+     * Returns the [a, b, c] specificity components.
+     *
+     * For rules created without explicit components, the (lossy) packed value is
+     * decomposed as a fallback, preserving the previous sorting behavior.
+     *
+     * @return int[]
+     */
+    private function resolveSpecificityValues()
+    {
+        if ($this->specificityValues !== null) {
+            return $this->specificityValues;
+        }
+
+        $value = $this->specificity->getValue();
+
+        return [
+            intdiv($value, 100),
+            intdiv($value % 100, 10),
+            $value % 10,
+        ];
     }
 }

--- a/src/CssToInlineStyles.php
+++ b/src/CssToInlineStyles.php
@@ -7,7 +7,6 @@ use Symfony\Component\CssSelector\Exception\ExceptionInterface;
 use TijsVerkoyen\CssToInlineStyles\Css\Processor;
 use TijsVerkoyen\CssToInlineStyles\Css\Property\Processor as PropertyProcessor;
 use TijsVerkoyen\CssToInlineStyles\Css\Property\Property;
-use TijsVerkoyen\CssToInlineStyles\Css\Rule\Processor as RuleProcessor;
 
 class CssToInlineStyles
 {
@@ -177,7 +176,27 @@ class CssToInlineStyles
 
         $xPath = new \DOMXPath($document);
 
-        usort($rules, array(RuleProcessor::class, 'sortOnSpecificity'));
+        // Sort the rules ascending by specificity. The specificity is compared on its
+        // (a, b, c) components rather than on Specificity::getValue(), because that single
+        // packed value misranks selectors with 10 or more class/type selectors (e.g. 11
+        // classes would beat an ID selector). Ties are broken by the document order.
+        $specificityA = [];
+        $specificityB = [];
+        $specificityC = [];
+        $orders = [];
+        foreach ($rules as $rule) {
+            $specificityA[] = $rule->getSpecificityA();
+            $specificityB[] = $rule->getSpecificityB();
+            $specificityC[] = $rule->getSpecificityC();
+            $orders[] = $rule->getOrder();
+        }
+        array_multisort(
+            $specificityA, SORT_ASC, SORT_NUMERIC,
+            $specificityB, SORT_ASC, SORT_NUMERIC,
+            $specificityC, SORT_ASC, SORT_NUMERIC,
+            $orders, SORT_ASC, SORT_NUMERIC,
+            $rules
+        );
 
         foreach ($rules as $rule) {
             try {
@@ -224,28 +243,16 @@ class CssToInlineStyles
 
         foreach ($properties as $property) {
             if (isset($cssProperties[$property->getName()])) {
-                $existingProperty = $cssProperties[$property->getName()];
-
-                //skip check to overrule if existing property is important and current is not
-                if ($existingProperty->isImportant() && !$property->isImportant()) {
+                if (!$property->isImportant() && $cssProperties[$property->getName()]->isImportant()) {
                     continue;
                 }
 
-                //overrule if current property is important and existing is not, else check specificity
-                $overrule = !$existingProperty->isImportant() && $property->isImportant();
-                if (!$overrule) {
-                    \assert($existingProperty->getOriginalSpecificity() !== null, 'Properties created for parsed CSS always have their associated specificity.');
-                    \assert($property->getOriginalSpecificity() !== null, 'Properties created for parsed CSS always have their associated specificity.');
-                    $overrule = $existingProperty->getOriginalSpecificity()->compareTo($property->getOriginalSpecificity()) <= 0;
-                }
-
-                if ($overrule) {
-                    unset($cssProperties[$property->getName()]);
-                    $cssProperties[$property->getName()] = $property;
-                }
-            } else {
-                $cssProperties[$property->getName()] = $property;
+                // assigning to an existing array key preserves the key's position,
+                // while the unset() + re-insert moves it to the end of the array
+                unset($cssProperties[$property->getName()]);
             }
+
+            $cssProperties[$property->getName()] = $property;
         }
 
         return $cssProperties;

--- a/tests/Css/Rule/ProcessorTest.php
+++ b/tests/Css/Rule/ProcessorTest.php
@@ -87,4 +87,18 @@ EOF;
             $this->processor->calculateSpecificityBasedOnASelector('a')
         );
     }
+
+    public function testRuleExposesSpecificityComponents(): void
+    {
+        $rules = $this->processor->convertToObjects(
+            '.c1.c2.c3.c4.c5.c6.c7.c8.c9.c10.c11 { color: red; }',
+            1
+        );
+
+        $this->assertCount(1, $rules);
+        // 11 class selectors => specificity (0, 11, 0)
+        $this->assertSame(0, $rules[0]->getSpecificityA());
+        $this->assertSame(11, $rules[0]->getSpecificityB());
+        $this->assertSame(0, $rules[0]->getSpecificityC());
+    }
 }

--- a/tests/Css/Rule/RuleTest.php
+++ b/tests/Css/Rule/RuleTest.php
@@ -26,4 +26,35 @@ class RuleTest extends TestCase
         $this->assertEquals($specificity, $rule->getSpecificity());
         $this->assertEquals(1, $rule->getOrder());
     }
+
+    public function testExplicitSpecificityComponents(): void
+    {
+        $rule = new Rule(
+            '#foo.bar',
+            array(new Property('padding', '5px')),
+            new Specificity(1, 1, 0),
+            1,
+            array(1, 1, 0)
+        );
+
+        $this->assertSame(1, $rule->getSpecificityA());
+        $this->assertSame(1, $rule->getSpecificityB());
+        $this->assertSame(0, $rule->getSpecificityC());
+    }
+
+    public function testSpecificityComponentsFallBackToDecomposedValue(): void
+    {
+        // When no explicit components are passed, they are decomposed from the
+        // (lossy) packed value, preserving the previous behavior.
+        $rule = new Rule(
+            '#foo.bar a',
+            array(new Property('padding', '5px')),
+            new Specificity(1, 1, 1),
+            1
+        );
+
+        $this->assertSame(1, $rule->getSpecificityA());
+        $this->assertSame(1, $rule->getSpecificityB());
+        $this->assertSame(1, $rule->getSpecificityC());
+    }
 }

--- a/tests/CssToInlineStylesTest.php
+++ b/tests/CssToInlineStylesTest.php
@@ -222,6 +222,19 @@ EOF;
         $this->assertCorrectConversion($expected, $html, $css);
     }
 
+    public function testIdSelectorBeatsManyClassSelectors(): void
+    {
+        // A selector with 11 classes has specificity (0, 11, 0); an ID selector
+        // has (1, 0, 0) and must win. This guards against ranking the specificity
+        // by Specificity::getValue() (0*100 + 11*10 = 110 vs 1*100 = 100), which
+        // would incorrectly let the classes win.
+        $html = '<p id="x" class="c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11"></p>';
+        $css = '.c1.c2.c3.c4.c5.c6.c7.c8.c9.c10.c11 { color: red; } #x { color: blue; }';
+        $expected = '<p id="x" class="c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11" style="color: blue;"></p>';
+
+        $this->assertCorrectConversion($expected, $html, $css);
+    }
+
     public function testInvalidSelector(): void
     {
         $html = "<p></p>";


### PR DESCRIPTION
This is my first contribution to this repository. I hope it's OK and please, tell me if I have to do anything else. Thanks.

-----

I was profiling some tests in a Symfony app and found this:

```
Global stats:

  Called functions    :     2.7M
  Distinct functions  :    10.2K

  Wall time           :    4.32s
  ZE memory usage     :   39.2MB

Flat profile:

 Wall time           | ZE memory usage     |
 Inc.     | *Exc.    | Inc.     | Exc.     | Called   | Function
----------+----------+----------+----------+----------+----------
  414.2ms |  414.2ms |    -384B |    -384B |      459 | Doctrine\DBAL\Driver\PDO\Connection::exec
  414.4ms |  414.0ms |  743.3KB |  743.3KB |      641 | Doctrine\DBAL\Driver\PDO\Statement::execute
  213.8ms |  191.2ms |  -22.3MB |  -22.3MB |      210 | phpDocumentor\Reflection\Types\ContextFactory::createForNamespace
  196.0ms |  118.9ms |       0B |       0B |   104.1K | TijsVerkoyen\CssToInlineStyles\Css\Rule\Processor::sortOnSpecificity
   42.8ms |   42.8ms |       0B |       0B |      125 | Doctrine\DBAL\Driver\PDO\Connection   ::commit
   33.2ms |   33.2ms |       0B |       0B |   106.8K | Symfony\Component\CssSelector\Node\Specificity::compareTo
   28.0ms |   28.0ms |   -3.1KB |   -3.1KB |       31 | Symfony\Component\DomCrawler\Crawler::copyFromHtml5ToDom
   24.4ms |   16.3ms |    2.6MB |    2.6MB |     3.6K | TijsVerkoyen\CssToInlineStyles\CssToInlineStyles::calculatePropertiesToBeApplied
   55.1ms |   12.7ms |  740.1KB |  312.4KB |       83 | Twig\Extension\CoreExtension::captureOutput
   12.2ms |   12.2ms |       0B |       0B |   126.6K | TijsVerkoyen\CssToInlineStyles\Css\Rule\Rule::getOrder
```

It was strange to me to see more than 100k function calls related to `CssToInlineStyles`. That's why I propose the two following changes to improve performance:

**(1)** **[Schwartzian transform](https://en.wikipedia.org/wiki/Schwartzian_transform) sort**: replaced `usort()` with PHP callback with `array_multisort()`. Sort keys (`getValue()` and `getOrder()`) are now computed once per rule in a single loop, and then the actual comparison is performed by PHP using C code.

**(2)** Simplified property merging: since rules are pre-sorted by ascending specificity, the `compareTo()` check in `calculatePropertiesToBeApplied()` was always `true`. Removed the redundant specificity comparison, `getOriginalSpecificity()` calls, assertions, and the unset/re-insert pattern. Only keep the `!important` related code.

This is the same profile **after applying this change**:

```
Global stats:

  Called functions    :     2.2M
  Distinct functions  :    10.2K

  Wall time           :    4.11s
  ZE memory usage     :   39.2MB

Flat profile:

 Wall time           | ZE memory usage     |
 Inc.     | *Exc.    | Inc.     | Exc.     | Called   | Function
----------+----------+----------+----------+----------+----------
  442.4ms |  442.1ms |  743.2KB |  743.2KB |      641 | Doctrine\DBAL\Driver\PDO\Statement::execute
  373.0ms |  372.5ms |  665.0KB |  665.0KB |     1.1K | Doctrine\DBAL\Driver\PDO\Connection::query
  211.2ms |  188.9ms |  -22.3MB |  -22.3MB |      210 | phpDocumentor\Reflection\Types\ContextFactory::createForNamespace
   41.2ms |   41.2ms |       0B |       0B |      125 | Doctrine\DBAL\Driver\PDO\Connection::commit
   37.8ms |   37.8ms |      96B |      96B |    26.8K | Doctrine\Deprecations\Deprecation::triggerIfCalledFromOutside
  107.1ms |   31.9ms |    1.1MB |    1.3MB |      691 | Doctrine\ORM\UnitOfWork::computeChangeSet
   34.5ms |   31.8ms |   -2.1MB |   -2.1MB |    11.7K | TijsVerkoyen\CssToInlineStyles\Css\Rule\Processor::calculateSpecificityBasedOnASelector
   27.9ms |   27.9ms |   -3.1KB |   -3.1KB |       31 | Symfony\Component\DomCrawler\Crawler::copyFromHtml5ToDom
   53.6ms |   12.8ms |  740.1KB |  312.4KB |       83 | Twig\Extension\CoreExtension::captureOutput
   38.6ms |   11.0ms |    5.6MB |    2.2MB |    12.7K | TijsVerkoyen\CssToInlineStyles\Css\Property\Processor::convertArrayToObjects
```